### PR TITLE
Add IDEAM weather integration for parapente detail

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'models/report.dart';
 import 'models/safe_route.dart';
 import 'models/user_preferences.dart';
+import 'pages/parapente_detail_page.dart';
 import 'services/local_storage_service.dart';
 import 'services/location_service.dart';
 import 'services/safe_route_local_data_source.dart';
@@ -524,6 +525,23 @@ class _RutasSegurasPageState extends State<RutasSegurasPage> {
     );
   }
 
+  bool _routeHasParapente(SafeRoute route) {
+    return route.pointsOfInterest
+        .any((String point) => point.toLowerCase().contains('parapente'));
+  }
+
+  Future<void> _openParapenteDetails() async {
+    if (!mounted) {
+      return;
+    }
+
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const ParapenteDetailPage(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
@@ -586,13 +604,23 @@ class _RutasSegurasPageState extends State<RutasSegurasPage> {
                   ),
                 ],
                 const SizedBox(height: 16),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton.icon(
-                    onPressed: () => _openRouteOnMap(route),
-                    icon: const Icon(Icons.map),
-                    label: const Text('Ver en Mapa'),
-                  ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: <Widget>[
+                    if (_routeHasParapente(route)) ...<Widget>[
+                      OutlinedButton.icon(
+                        onPressed: _openParapenteDetails,
+                        icon: const Icon(Icons.airplanemode_active),
+                        label: const Text('Clima para Parapente'),
+                      ),
+                      const SizedBox(width: 12),
+                    ],
+                    FilledButton.icon(
+                      onPressed: () => _openRouteOnMap(route),
+                      icon: const Icon(Icons.map),
+                      label: const Text('Ver en Mapa'),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/models/ideam_weather.dart
+++ b/lib/models/ideam_weather.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/foundation.dart';
+
+/// Represents the most relevant weather values returned by the IDEAM service
+/// for a particular station/municipality.
+@immutable
+class IdeamWeather {
+  const IdeamWeather({
+    required this.stationName,
+    this.municipality,
+    this.temperatureCelsius,
+    this.feelsLikeCelsius,
+    this.humidityPercentage,
+    this.windSpeedMs,
+    this.windDirection,
+    this.pressureHpa,
+    this.precipitationMm,
+    this.observationTime,
+  });
+
+  /// Nombre de la estación reportado por el IDEAM.
+  final String stationName;
+
+  /// Municipio asociado al reporte, si está disponible.
+  final String? municipality;
+
+  /// Temperatura ambiente en °C.
+  final double? temperatureCelsius;
+
+  /// Sensación térmica (en °C) si la API la reporta.
+  final double? feelsLikeCelsius;
+
+  /// Humedad relativa en porcentaje (0-100).
+  final double? humidityPercentage;
+
+  /// Velocidad del viento en metros por segundo.
+  final double? windSpeedMs;
+
+  /// Dirección del viento en formato textual o grados.
+  final String? windDirection;
+
+  /// Presión atmosférica en hPa.
+  final double? pressureHpa;
+
+  /// Precipitación acumulada (mm) en el periodo informado.
+  final double? precipitationMm;
+
+  /// Momento de la observación.
+  final DateTime? observationTime;
+
+  /// Convierte una estructura JSON proporcionada por el servicio IDEAM en un
+  /// objeto [IdeamWeather]. El servicio suele envolver los valores dentro de
+  /// la clave `attributes`.
+  factory IdeamWeather.fromFeature(Map<String, dynamic> feature) {
+    final Map<String, dynamic> attributes = (feature['attributes'] as Map<String, dynamic>?) ?? feature;
+
+    double? _asDouble(dynamic value) {
+      if (value == null) {
+        return null;
+      }
+      if (value is num) {
+        return value.toDouble();
+      }
+      if (value is String) {
+        return double.tryParse(value.replaceAll(',', '.'));
+      }
+      return null;
+    }
+
+    DateTime? _asDateTime(dynamic value) {
+      if (value == null) {
+        return null;
+      }
+      if (value is int) {
+        // Algunos servicios ArcGIS retornan milisegundos desde la época Unix.
+        try {
+          return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true).toLocal();
+        } catch (_) {
+          return null;
+        }
+      }
+      if (value is String && value.isNotEmpty) {
+        return DateTime.tryParse(value)?.toLocal();
+      }
+      return null;
+    }
+
+    String _trimmed(dynamic value) {
+      if (value == null) {
+        return '';
+      }
+      return value.toString().trim();
+    }
+
+    final String stationName = _trimmed(
+      attributes['nombre_estacion'] ?? attributes['NombreEstacion'] ?? attributes['station'] ?? attributes['name'],
+    );
+    final String municipality = _trimmed(
+      attributes['municipio'] ?? attributes['Municipio'] ?? attributes['city'] ?? attributes['municipality'],
+    );
+    final String direction = _trimmed(
+      attributes['direccion_viento'] ?? attributes['DireccionViento'] ?? attributes['wind_direction'],
+    );
+
+    return IdeamWeather(
+      stationName: stationName.isEmpty ? 'Estación IDEAM' : stationName,
+      municipality: municipality.isEmpty ? null : municipality,
+      temperatureCelsius: _asDouble(attributes['temperatura'] ?? attributes['Temperatura'] ?? attributes['temp']),
+      feelsLikeCelsius: _asDouble(attributes['sensacion'] ?? attributes['SensacionTermica'] ?? attributes['feels_like']),
+      humidityPercentage: _asDouble(attributes['humedad'] ?? attributes['Humedad'] ?? attributes['humidity']),
+      windSpeedMs: _asDouble(attributes['velocidad_viento'] ?? attributes['VelocidadViento'] ?? attributes['wind_speed']),
+      windDirection: direction.isEmpty ? null : direction,
+      pressureHpa: _asDouble(attributes['presion'] ?? attributes['Presion'] ?? attributes['pressure']),
+      precipitationMm: _asDouble(attributes['precipitacion'] ?? attributes['Precipitacion'] ?? attributes['rain']),
+      observationTime: _asDateTime(attributes['fecha_observacion'] ?? attributes['FechaObservacion'] ?? attributes['timestamp']),
+    );
+  }
+
+  /// Velocidad del viento convertida a km/h.
+  double? get windSpeedKmh {
+    final double? speed = windSpeedMs;
+    if (speed == null) {
+      return null;
+    }
+    return speed * 3.6;
+  }
+}

--- a/lib/pages/parapente_detail_page.dart
+++ b/lib/pages/parapente_detail_page.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+
+import '../models/ideam_weather.dart';
+import '../services/ideam_weather_service.dart';
+
+class ParapenteDetailPage extends StatefulWidget {
+  const ParapenteDetailPage({super.key});
+
+  @override
+  State<ParapenteDetailPage> createState() => _ParapenteDetailPageState();
+}
+
+class _ParapenteDetailPageState extends State<ParapenteDetailPage> {
+  late final IdeamWeatherService _weatherService;
+  late Future<IdeamWeather> _weatherFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _weatherService = IdeamWeatherService();
+    _weatherFuture = _weatherService.fetchVillavicencioWeather();
+  }
+
+  @override
+  void dispose() {
+    _weatherService.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Condiciones para Parapente'),
+      ),
+      body: FutureBuilder<IdeamWeather>(
+        future: _weatherFuture,
+        builder: (BuildContext context, AsyncSnapshot<IdeamWeather> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return _ErrorView(
+              error: snapshot.error,
+              onRetry: () {
+                setState(() {
+                  _weatherFuture = _weatherService.fetchVillavicencioWeather();
+                });
+              },
+            );
+          }
+
+          final IdeamWeather weather = snapshot.requireData;
+          return RefreshIndicator(
+            onRefresh: () async {
+              setState(() {
+                _weatherFuture = _weatherService.fetchVillavicencioWeather();
+              });
+              await _weatherFuture;
+            },
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: <Widget>[
+                _WeatherHeader(weather: weather),
+                const SizedBox(height: 16),
+                _WeatherValueTile(
+                  icon: Icons.thermostat,
+                  label: 'Temperatura',
+                  value: weather.temperatureCelsius != null
+                      ? '${weather.temperatureCelsius!.toStringAsFixed(1)} °C'
+                      : 'No disponible',
+                ),
+                _WeatherValueTile(
+                  icon: Icons.water_drop,
+                  label: 'Humedad relativa',
+                  value: weather.humidityPercentage != null
+                      ? '${weather.humidityPercentage!.toStringAsFixed(0)} %'
+                      : 'No disponible',
+                ),
+                _WeatherValueTile(
+                  icon: Icons.air,
+                  label: 'Velocidad del viento',
+                  value: weather.windSpeedKmh != null
+                      ? '${weather.windSpeedKmh!.toStringAsFixed(1)} km/h'
+                      : 'No disponible',
+                ),
+                if (weather.windDirection != null)
+                  _WeatherValueTile(
+                    icon: Icons.explore,
+                    label: 'Dirección del viento',
+                    value: weather.windDirection!,
+                  ),
+                _WeatherValueTile(
+                  icon: Icons.speed,
+                  label: 'Presión atmosférica',
+                  value: weather.pressureHpa != null
+                      ? '${weather.pressureHpa!.toStringAsFixed(0)} hPa'
+                      : 'No disponible',
+                ),
+                _WeatherValueTile(
+                  icon: Icons.grain,
+                  label: 'Precipitación',
+                  value: weather.precipitationMm != null
+                      ? '${weather.precipitationMm!.toStringAsFixed(1)} mm'
+                      : 'No disponible',
+                ),
+                if (weather.feelsLikeCelsius != null)
+                  _WeatherValueTile(
+                    icon: Icons.local_fire_department,
+                    label: 'Sensación térmica',
+                    value: '${weather.feelsLikeCelsius!.toStringAsFixed(1)} °C',
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WeatherHeader extends StatelessWidget {
+  const _WeatherHeader({required this.weather});
+
+  final IdeamWeather weather;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final DateTime? observation = weather.observationTime;
+    final String subtitle;
+    if (observation != null) {
+      subtitle = 'Actualizado: ${TimeOfDay.fromDateTime(observation).format(context)}';
+    } else {
+      subtitle = 'Última actualización no disponible';
+    }
+
+    return Card(
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              weather.stationName,
+              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              weather.municipality != null
+                  ? '${weather.municipality}, Meta'
+                  : 'Villavicencio, Meta',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              subtitle,
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WeatherValueTile extends StatelessWidget {
+  const _WeatherValueTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: <Widget>[
+            Icon(icon, color: Theme.of(context).colorScheme.primary),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    label,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(value),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    required this.error,
+    required this.onRetry,
+  });
+
+  final Object? error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.cloud_off,
+              size: 48,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No se pudo obtener la información meteorológica.',
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            if (error != null)
+              Text(
+                error.toString(),
+                style: theme.textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Reintentar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/ideam_weather_service.dart
+++ b/lib/services/ideam_weather_service.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import '../models/ideam_weather.dart';
+
+/// Maneja las peticiones al servicio público del IDEAM para obtener las
+/// condiciones meteorológicas más recientes de Villavicencio.
+class IdeamWeatherService {
+  IdeamWeatherService({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client();
+
+  static const String _host = 'geoportal.ideam.gov.co';
+  static const String _path =
+      '/geoportal/rest/services/IDEAM/observacion_meteorologica/MapServer/0/query';
+  static const String _municipality = 'VILLAVICENCIO';
+
+  final http.Client _httpClient;
+
+  /// Construye la URL de consulta para obtener la observación más reciente del
+  /// municipio de Villavicencio.
+  Uri _buildVillavicencioUrl() {
+    return Uri.https(_host, _path, <String, String>{
+      'f': 'json',
+      'where': "Municipio='$_municipality'",
+      'outFields': 'Municipio,NombreEstacion,Temperatura,VelocidadViento,DireccionViento,Humedad,Presion,Precipitacion,FechaObservacion',
+      'orderByFields': 'FechaObservacion DESC',
+      'resultRecordCount': '1',
+    });
+  }
+
+  /// Obtiene el reporte meteorológico del IDEAM para Villavicencio.
+  Future<IdeamWeather> fetchVillavicencioWeather() async {
+    final Uri uri = _buildVillavicencioUrl();
+
+    http.Response response;
+    try {
+      response = await _httpClient.get(uri);
+    } on SocketException catch (error) {
+      throw IdeamWeatherException('No fue posible conectarse con el IDEAM.', error);
+    } on HttpException catch (error) {
+      throw IdeamWeatherException('La solicitud al IDEAM falló.', error);
+    } catch (error) {
+      throw IdeamWeatherException('Ocurrió un error inesperado al consultar el IDEAM.', error);
+    }
+
+    if (response.statusCode != HttpStatus.ok) {
+      throw IdeamWeatherException(
+        'El IDEAM respondió con un estado inesperado (${response.statusCode}).',
+        response.statusCode,
+      );
+    }
+
+    Map<String, dynamic> data;
+    try {
+      data = jsonDecode(response.body) as Map<String, dynamic>;
+    } catch (error) {
+      throw IdeamWeatherException('No fue posible leer la respuesta del IDEAM.', error);
+    }
+
+    final List<dynamic> features = (data['features'] as List<dynamic>?) ?? const <dynamic>[];
+    if (features.isEmpty) {
+      throw IdeamWeatherException('El IDEAM no retornó datos meteorológicos para Villavicencio.');
+    }
+
+    final Map<String, dynamic>? feature = features.first as Map<String, dynamic>?;
+    if (feature == null || feature.isEmpty) {
+      throw IdeamWeatherException('El formato del dato meteorológico recibido es inválido.');
+    }
+
+    return IdeamWeather.fromFeature(feature);
+  }
+
+  /// Libera los recursos del cliente HTTP.
+  void dispose() {
+    _httpClient.close();
+  }
+}
+
+/// Error personalizado para las operaciones del servicio del IDEAM.
+class IdeamWeatherException implements Exception {
+  IdeamWeatherException(this.message, [this.detail]);
+
+  final String message;
+  final Object? detail;
+
+  @override
+  String toString() => 'IdeamWeatherException($message, detail: $detail)';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   shared_preferences: ^2.2.3
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add the `http` client dependency to prepare the project for REST requests
- implement an IDEAM weather model and service to fetch Villavicencio conditions
- expose a new parapente detail screen that shows IDEAM data with loading and error states

## Testing
- `flutter pub get` *(fails: flutter command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e648be38832d91b7b51352f6a6ed